### PR TITLE
fix for working with ractive >= 0.9

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@
   }
 
 }(this, function (Ractive, Hammer) {
+  
+  Ractive = Ractive && Ractive.__esModule ? Ractive['default'] : Ractive;
+  Hammer  = Hammer && Hammer.__esModule ? Hammer['default'] : Hammer;
 
   // Check the recognizers documentation.
   // http://hammerjs.github.io/recognizer-tap


### PR DESCRIPTION
Could not use this lib when upgrading to ractive >= 0.9 thought I'd put this small fix in